### PR TITLE
Update wallaby.js

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -48,7 +48,12 @@ module.exports = (wallaby) => {
 
     return {
         compilers: {
-            '**/*.js': wallaby.compilers.babel()
+            '**/*.js': wallaby.compilers.babel({
+                babelrc: true,
+                plugins: [
+                  'transform-es2015-modules-amd'
+                ]
+            })
         },
 
         debug: true,
@@ -66,7 +71,7 @@ module.exports = (wallaby) => {
             app.use('/scripts', express.static(path.join(__dirname, 'scripts')));
         },
 
-        setup: ((w) => {
+        setup: (function(w) {
             w.delayStart();
 
             requirejs.config({
@@ -81,7 +86,7 @@ module.exports = (wallaby) => {
                 ]
             });
 
-            require(['test/unit/setup.js'].concat(w.tests), () => {
+            require(['test/unit/setup.js'].concat(w.tests), function() {
                 w.start();
             });
         }).toString().replace('// packages', packages)


### PR DESCRIPTION
Changes:
- As described here: https://github.com/wallabyjs/public/issues/897#issuecomment-265720599, you need to add the `transform-es2015-modules-amd` babel plugin.
- You were using arrow functions in your `setup` function. PhantomJs (which is used) by default, doesn't support them, so were were getting the errors you've reported in the email. You may either replace the arrow functions to normal functions, like I did in the PR, or use Electron runner (as described in the referenced issue) that supports arrows.